### PR TITLE
Fix font deployment issue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,7 +89,8 @@ export default function RootLayout({
       </head>
       <body
         className={cn(
-          "min-h-screen bg-background font-sans antialiased max-w-[720px] mx-auto py-6 sm:py-10 px-4 sm:px-6"
+          "min-h-screen bg-background font-sans antialiased max-w-[720px] mx-auto py-6 sm:py-10 px-4 sm:px-6",
+          fontSans.variable
         )}
       >
         <ThemeProvider attribute="class" defaultTheme="light">


### PR DESCRIPTION
Add `fontSans.variable` to the `<body>` element to fix font fallback to Times New Roman in production deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad821ec4-cc8b-4e04-a28f-9f7a42dd5a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad821ec4-cc8b-4e04-a28f-9f7a42dd5a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

